### PR TITLE
Fresh commit of "Create open registration E2E example""

### DIFF
--- a/cpp_extensions/open_registration_extension.cpp
+++ b/cpp_extensions/open_registration_extension.cpp
@@ -1,0 +1,122 @@
+#include <c10/core/impl/alloc_cpu.h>
+#include <c10/core/Allocator.h>
+
+#include <torch/csrc/Device.h>
+#include <torch/extension.h>
+
+#include <ATen/native/cpu/Loops.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/EmptyTensor.h>
+
+#include <iostream>
+
+// This file contains the heavy lifting to add a new C++ backend
+// and integrate it directly into the PyTorch backend. It mainly involves:
+//
+// (1) Writing a custom allocator and registering it to pytorch
+//     (see DummyCustomAllocator)
+// (2) Writing a custom aten::empty.memory_format function
+
+
+// basic dummy add function
+at::Tensor custom_add_Tensor(const at::Tensor & self, const at::Tensor & other, const at::Scalar & alpha) {
+  std::cout << "Custom aten::add.Tensor() called!" << std::endl;
+  // Since this custom device is just for testing, not bothering to implement kernels.
+  return at::empty(self.sizes(), self.options());
+}
+
+// A dummy allocator for our custom device, that secretly uses the CPU
+struct DummyCustomAllocator final : at::Allocator {
+  DummyCustomAllocator() = default;
+  at::DataPtr allocate(size_t nbytes) const override {
+    std::cout << "Custom allocator's allocate() called!" << std::endl;
+    void* data = c10::alloc_cpu(nbytes);
+    return {data, data, &ReportAndDelete, at::Device(at::DeviceType::PrivateUse1, 0)};
+  }
+
+  static void ReportAndDelete(void* ptr) {
+    if (!ptr) {
+      return;
+    }
+    std::cout << "Custom allocator's delete() called!" << std::endl;
+    c10::free_cpu(ptr);
+  }
+
+  at::DeleterFnPtr raw_deleter() const override {
+    return &ReportAndDelete;
+  }
+};
+
+// Register our dummy allocator
+static DummyCustomAllocator global_custom_alloc;
+REGISTER_ALLOCATOR(c10::DeviceType::PrivateUse1, &global_custom_alloc);
+
+// basic dummy empty function, so we can directly construct tensors on the custom device
+// This dummy test device will just use the CPU allocator, and ignores pinned memory.
+//
+// Note: this kernel is very simple because our "custom device" just uses the normal TensorImpl object
+// to store data under the hood.
+// In PyTorch core today, both cpu and cuda are implemented with an ordinary TensorImpl class.
+// Sometimes, backends prefer to subclass TensorImpl in order to store extra information.
+// If this is the case, then this kernel is where you'll be responsible for creating and returning
+// a fresh at::Tensor object, that properly stores a TensorImpl of your subclass.
+at::Tensor custom_empty_memory_format(at::IntArrayRef size, c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout, c10::optional<at::Device> device, c10::optional<bool> pin_memory, c10::optional<at::MemoryFormat> memory_format) {
+  std::cout << "Custom aten::empty.memory_format() called!" << std::endl;
+  constexpr c10::DispatchKeySet private_use_ks(c10::DispatchKey::PrivateUse1);
+  return at::detail::empty_generic(size, &global_custom_alloc, private_use_ks, c10::dtype_or_default(dtype), memory_format);
+}
+
+at::Tensor & custom_fill__scalar(at::Tensor & self, const at::Scalar & value) {
+  // Not bothering to implement.
+  // Should fill the tensor's data with "value".
+  return self;
+}
+
+// basic dummy copy_() function, so we can copy from the custom device to/from CPU
+at::Tensor custom__copy_from(const at::Tensor& self, const at::Tensor& dst, bool non_blocking) {
+  std::cout << "Custom aten::_copy_from() called!" << std::endl;
+  TORCH_CHECK(self.is_cpu() || self.device().type() == c10::DeviceType::PrivateUse1, "Dummy test only allows copy from cpu -> dummy device.");
+  TORCH_CHECK(dst.is_cpu() || dst.device().type() == c10::DeviceType::PrivateUse1, "Dummy test only allows copy from cpu -> dummy device.");
+
+  // Some dummy asserts for the basic use case: inputs are the same size / dtype, all contiguous.
+  TORCH_CHECK(self.sizes() == dst.sizes());
+  TORCH_CHECK(self.scalar_type() == dst.scalar_type());
+  TORCH_CHECK(self.is_contiguous() && dst.is_contiguous());
+
+  std::memcpy(dst.storage().data_ptr().get(), self.storage().data_ptr().get(), self.storage().nbytes());
+  return dst;
+}
+
+
+// This macro does the heavy lifting.
+// With TORCH_LIBRARY_IMPL, you can register custom kernels for your backend.
+// For open registration, we're registering all of our kernels to the PrivateUse1 dispatch key.
+// Later in this file, we map a custom device to the PrivateUse1 device type,
+// which allows user code that puts a tensor on your custom_device to eventually get plumbed
+// into the kernels registered here.
+//
+// This macro registers your kernels to the PyTorch Dispatcher.
+// More details on the dispatcher can be found at http://blog.ezyang.com/2020/09/lets-talk-about-the-pytorch-dispatcher/.
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
+  m.impl("add.Tensor", &custom_add_Tensor);
+  m.impl("empty.memory_format", &custom_empty_memory_format);
+  m.impl("fill_.Scalar", &custom_fill__scalar);
+  m.impl("_copy_from", &custom__copy_from);
+}
+
+// This basic implementation doesn't bother dealing with different device indices
+// (e.g. custom_device:0 vs. custom_device:1).
+// We could do that by letting the user pass in a device index in our exposed device function.
+// Note that if you do that, you'll also need to register a device guard to core.
+// See `c10/core/impl/DeviceGuardImplInterface.h:C10_REGISTER_GUARD_IMPL`.
+c10::Device get_custom_device(int idx) {
+  return c10::Device(c10::DeviceType::PrivateUse1, idx);
+}
+
+// Here, we're exposing a custom device object that corresponds to our custom backend.
+// We do this using pybind: exposing an "extension_name.custom_device()" function in python,
+// that's implemented in C++.
+// The implementation in this file maps directly to the `PrivateUse1` device type.
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("custom_device", &get_custom_device, "get custom device object");
+}

--- a/cpp_extensions/open_registration_extension.cpp
+++ b/cpp_extensions/open_registration_extension.cpp
@@ -1,0 +1,107 @@
+#include <c10/core/impl/alloc_cpu.h>
+#include <c10/core/Allocator.h>
+
+#include <torch/csrc/Device.h>
+#include <torch/extension.h>
+
+#include <ATen/native/cpu/Loops.h>
+#include <ATen/native/DispatchStub.h>
+#include <ATen/EmptyTensor.h>
+
+#include <iostream>
+
+
+// basic dummy add function
+at::Tensor custom_add_Tensor(const at::Tensor & self, const at::Tensor & other, const at::Scalar & alpha) {
+  std::cout << "Custom aten::add.Tensor() called!" << std::endl;
+  // Since this custom device is just for testing, not bothering to implement kernels.
+  return at::empty(self.sizes(), self.options());
+}
+
+// A dummy allocator for our custom device, that secretly uses the CPU
+struct DummyCustomAllocator final : at::Allocator {
+  DummyCustomAllocator() = default;
+  at::DataPtr allocate(size_t nbytes) const override {
+    std::cout << "Custom allocator's allocate() called!" << std::endl;
+    void* data = c10::alloc_cpu(nbytes);
+    return {data, data, &ReportAndDelete, at::Device(at::DeviceType::PrivateUse1, 0)};
+  }
+
+  static void ReportAndDelete(void* ptr) {
+    if (!ptr) {
+      return;
+    }
+    std::cout << "Custom allocator's delete() called!" << std::endl;
+    c10::free_cpu(ptr);
+  }
+
+  at::DeleterFnPtr raw_deleter() const override {
+    return &ReportAndDelete;
+  }
+};
+
+// Register our dummy allocator
+static DummyCustomAllocator global_custom_alloc;
+REGISTER_ALLOCATOR(c10::DeviceType::PrivateUse1, &global_custom_alloc);
+
+// basic dummy empty function, so we can directly construct tensors on the custom device
+// This dummy test device will just use the CPU allocator, and ignores pinned memory.
+at::Tensor custom_empty_memory_format(at::IntArrayRef size, c10::optional<at::ScalarType> dtype, c10::optional<at::Layout> layout, c10::optional<at::Device> device, c10::optional<bool> pin_memory, c10::optional<at::MemoryFormat> memory_format) {
+  std::cout << "Custom aten::empty.memory_format() called!" << std::endl;
+  constexpr c10::DispatchKeySet private_use_ks(c10::DispatchKey::PrivateUse1);
+  return at::detail::empty_generic(size, &global_custom_alloc, private_use_ks, c10::dtype_or_default(dtype), memory_format);
+}
+
+at::Tensor & custom_fill__scalar(at::Tensor & self, const at::Scalar & value) {
+  // Not bothering to implement.
+  return self;
+}
+
+// basic dummy copy_() function, so we can copy from the custom device to/from CPU
+at::Tensor custom__copy_from(const at::Tensor& self, const at::Tensor& dst, bool non_blocking) {
+  std::cout << "Custom aten::_copy_from() called!" << std::endl;
+  TORCH_CHECK(self.is_cpu() || self.device().type() == c10::DeviceType::PrivateUse1, "Dummy test only allows copy from cpu -> dummy device.");
+  TORCH_CHECK(dst.is_cpu() || dst.device().type() == c10::DeviceType::PrivateUse1, "Dummy test only allows copy from cpu -> dummy device.");
+
+  // Some dummy asserts for the basic use case: inputs are the same size / dtype, all contiguous.
+  TORCH_CHECK(self.sizes() == dst.sizes());
+  TORCH_CHECK(self.scalar_type() == dst.scalar_type());
+  TORCH_CHECK(self.is_contiguous() && dst.is_contiguous());
+
+  std::memcpy(dst.storage().data_ptr().get(), self.storage().data_ptr().get(), self.storage().nbytes());
+  return dst;
+}
+
+
+// This macro does the heavy lifting.
+// With TORCH_LIBRARY_IMPL, you can register custom kernels for your backend.
+// For open registration, we're registering all of our kernels to the PrivateUse1 dispatch key.
+// Later in this file, we map a custom device to the PrivateUse1 device type,
+// which allows user code that puts a tensor on your custom_device to eventually get plumbed
+// into the kernels registered here.
+//
+// This macro registers your kernels to the PyTorch Dispatcher.
+// More details on the dispatcher can be found at http://blog.ezyang.com/2020/09/lets-talk-about-the-pytorch-dispatcher/.
+TORCH_LIBRARY_IMPL(aten, PrivateUse1, m) {
+  m.impl("add.Tensor", &custom_add_Tensor);
+  m.impl("empty.memory_format", &custom_empty_memory_format);
+  m.impl("fill_.Scalar", &custom_fill__scalar);
+  m.impl("_copy_from", &custom__copy_from);
+}
+
+// This basic implementation doesn't bother dealing with different device indices
+// (e.g. custom_device:0 vs. custom_device:1).
+// We could do that by letting the user pass in a device index in our exposed device function.
+// Note that if you do that, you'll also need to register a device guard to core.
+// See `c10/core/impl/DeviceGuardImplInterface.h:C10_REGISTER_GUARD_IMPL`.
+c10::Device get_custom_device(int idx) {
+  return c10::Device(c10::DeviceType::PrivateUse1, idx);
+}
+
+// Here, we're exposing a custom device object that corresponds to our custom backend.
+// We do this using pybind: exposing an "extension_name.custom_device()" function in python,
+// that's implemented in C++.
+// The implementation in this file maps directly to the `PrivateUse1` device type.
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("custom_device", &get_custom_device, "get custom device object");
+}

--- a/open_registration_example.py
+++ b/open_registration_example.py
@@ -1,0 +1,120 @@
+import torch
+from utils.custom_device_mode import foo_module, enable_foo_device
+
+# This file contains an example of how to create a custom device extension
+# in PyTorch, through the dispatcher.
+# It also shows what two possible user API's for custom devices look like. Either:
+# (1) Expose your custom device as an object, device=my_device_obj
+# (2) Ask users to enable a TorchFunctionMode, so you can use device strings: device="my_device"
+
+# Running this file prints the following:
+
+# Loaded custom extension.
+# (Correctly) unable to create tensor on device='bar'
+# Creating x on device 'foo:0'
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+# Creating y on device 'foo:0'
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+
+# Test START
+# x.device=privateuseone:0, x.is_cpu=False
+# y.device=privateuseone:0, y.is_cpu=False
+# Calling z = x + y
+# Custom aten::add.Tensor() called!
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+# z.device=privateuseone:0, z.is_cpu=False
+# Calling z = z.to(device="cpu")
+# Custom aten::_copy_from() called!
+# z_cpu.device=cpu, z_cpu.is_cpu=True
+# Calling z2 = z_cpu + z_cpu
+# Test END
+
+# Custom allocator's delete() called!
+# Creating x on device 'foo:1'
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+# Creating y on device 'foo:1'
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+
+# Test START
+# x.device=privateuseone:0, x.is_cpu=False
+# y.device=privateuseone:0, y.is_cpu=False
+# Calling z = x + y
+# Custom aten::add.Tensor() called!
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+# z.device=privateuseone:0, z.is_cpu=False
+# Calling z = z.to(device="cpu")
+# Custom aten::_copy_from() called!
+# z_cpu.device=cpu, z_cpu.is_cpu=True
+# Calling z2 = z_cpu + z_cpu
+# Test END
+
+# Custom allocator's delete() called!
+# Custom allocator's delete() called!
+# Custom allocator's delete() called!
+# Custom allocator's delete() called!
+# Custom allocator's delete() called!
+
+
+def test(x, y):
+    print()
+    print("Test START")
+    # Check that our device is correct.
+    print(f'x.device={x.device}, x.is_cpu={x.is_cpu}')
+    print(f'y.device={y.device}, y.is_cpu={y.is_cpu}')
+
+    # calls out custom add kernel, registered to the dispatcher
+    print('Calling z = x + y')
+    z = x + y
+    print(f'z.device={z.device}, z.is_cpu={z.is_cpu}')
+
+    print('Calling z = z.to(device="cpu")')
+    z_cpu = z.to(device='cpu')
+
+    # Check that our cross-device copy correctly copied the data to cpu
+    print(f'z_cpu.device={z_cpu.device}, z_cpu.is_cpu={z_cpu.is_cpu}')
+
+    # Confirm that calling the add kernel no longer invokes our custom kernel,
+    # since we're using CPU t4ensors.
+    print('Calling z2 = z_cpu + z_cpu')
+    z2 = z_cpu + z_cpu
+    print("Test END")
+    print()
+
+# Option 1: Use a TorchFunctionMode object, that will convert `device="foo"` calls
+# into our custom device objects automatically.
+_holder = enable_foo_device()
+
+try:
+    x = torch.ones(4, 4, device='bar')
+    exit("Error: you should not be able to make a tensor on an arbitrary 'bar' device.")
+except RuntimeError as e:
+    print("(Correctly) unable to create tensor on device='bar'")
+
+print("Creating x on device 'foo:0'")
+x1 = torch.ones(4, 4, device='foo:0')
+print("Creating y on device 'foo:0'")
+y1 = torch.ones(4, 4, device='foo:0')
+
+test(x1, y1)
+
+# Normally you would probably want this device TorchFunction translation to happen
+# permanently, bu this example I want to remove it.
+del _holder
+
+
+# Option 2: Directly expose a custom device object
+# You can pass an optional index arg, specifying which device index to use.
+foo_device1 = foo_module.custom_device(1)
+
+print("Creating x on device 'foo:1'")
+x2 = torch.ones(4, 4, device=foo_device1)
+print("Creating y on device 'foo:1'")
+y2 = torch.ones(4, 4, device=foo_device1)
+
+test(x2, y2)

--- a/open_registration_example.py
+++ b/open_registration_example.py
@@ -1,0 +1,127 @@
+import os
+import shutil
+import torch
+from utils.custom_device_mode import foo_module, enable_foo_device
+
+# This file contains an example of how to create a custom device extension
+# in PyTorch, through the dispatcher.
+# It also shows what two possible user API's for custom devices look like. Either:
+# (1) Expose your custom device as an object, device=my_device_obj
+# (2) Ask users to enable a TorchFunctionMode, so you can use device strings: device="my_device"
+
+# Running this file prints the following:
+
+# Loaded custom extension.
+# (Correctly) unable to create tensor on device='bar'
+# Creating x on device 'foo:0'
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+# Creating y on device 'foo:0'
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+
+# Test START
+# x.device=privateuseone:0, x.is_cpu=False
+# y.device=privateuseone:0, y.is_cpu=False
+# Calling z = x + y
+# Custom aten::add.Tensor() called!
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+# z.device=privateuseone:0, z.is_cpu=False
+# Calling z = z.to(device="cpu")
+# Custom aten::_copy_from() called!
+# z_cpu.device=cpu, z_cpu.is_cpu=True
+# Calling z2 = z_cpu + z_cpu
+# Test END
+
+# Custom allocator's delete() called!
+# Creating x on device 'foo:1'
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+# Creating y on device 'foo:1'
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+
+# Test START
+# x.device=privateuseone:0, x.is_cpu=False
+# y.device=privateuseone:0, y.is_cpu=False
+# Calling z = x + y
+# Custom aten::add.Tensor() called!
+# Custom aten::empty.memory_format() called!
+# Custom allocator's allocate() called!
+# z.device=privateuseone:0, z.is_cpu=False
+# Calling z = z.to(device="cpu")
+# Custom aten::_copy_from() called!
+# z_cpu.device=cpu, z_cpu.is_cpu=True
+# Calling z2 = z_cpu + z_cpu
+# Test END
+
+# Custom allocator's delete() called!
+# Custom allocator's delete() called!
+# Custom allocator's delete() called!
+# Custom allocator's delete() called!
+# Custom allocator's delete() called!
+
+
+def test(x, y):
+    print()
+    print("Test START")
+    # Check that our device is correct.
+    print(f'x.device={x.device}, x.is_cpu={x.is_cpu}')
+    print(f'y.device={y.device}, y.is_cpu={y.is_cpu}')
+
+    # calls out custom add kernel, registered to the dispatcher
+    print('Calling z = x + y')
+    z = x + y
+    print(f'z.device={z.device}, z.is_cpu={z.is_cpu}')
+
+    print('Calling z = z.to(device="cpu")')
+    z_cpu = z.to(device='cpu')
+
+    # Check that our cross-device copy correctly copied the data to cpu
+    print(f'z_cpu.device={z_cpu.device}, z_cpu.is_cpu={z_cpu.is_cpu}')
+
+    # Confirm that calling the add kernel no longer invokes our custom kernel,
+    # since we're using CPU t4ensors.
+    print('Calling z2 = z_cpu + z_cpu')
+    z2 = z_cpu + z_cpu
+    print("Test END")
+    print()
+
+# Option 1: Use a TorchFunctionMode object, that will convert `device="foo"` calls
+# into our custom device objects automatically.
+_holder = enable_foo_device()
+
+try:
+    x = torch.empty(4, 4, device='bar')
+    exit("Error: you should not be able to make a tensor on an arbitrary 'bar' device.")
+except RuntimeError as e:
+    print("(Correctly) unable to create tensor on device='bar'")
+
+print("Creating x on device 'foo:0'")
+x1 = torch.empty(4, 4, device='foo:0')
+print("Creating y on device 'foo:0'")
+y1 = torch.empty(4, 4, device='foo:0')
+
+test(x1, y1)
+
+# Normally you would probably want this device TorchFunction translation to happen
+# permanently, bu this example I want to remove it.
+del _holder
+
+
+# Option 2: Directly expose a custom device object
+# You can pass an optional index arg, specifying which device index to use.
+foo_device1 = foo_module.custom_device(1)
+
+print("Creating x on device 'foo:1'")
+x2 = torch.empty(4, 4, device=foo_device1)
+print("Creating y on device 'foo:1'")
+y2 = torch.empty(4, 4, device=foo_device1)
+
+test(x2, y2)
+
+# Some cleanup
+default_build_root = torch.utils.cpp_extension.get_default_build_root()
+if os.path.exists(default_build_root):
+    shutil.rmtree(default_build_root, ignore_errors=True)

--- a/utils/custom_device_mode.py
+++ b/utils/custom_device_mode.py
@@ -1,0 +1,45 @@
+import torch
+import torch.utils.cpp_extension
+from torch.overrides import enable_torch_function_mode, TorchFunctionMode
+
+# Load the C++ extension containing your custom kernels.
+foo_module = torch.utils.cpp_extension.load(
+    name="custom_device_extension",
+    sources=[
+        "cpp_extensions/open_registration_extension.cpp",
+    ],
+    extra_include_paths=["cpp_extensions"],
+    extra_cflags=["-g"],
+    verbose=True,
+)
+
+print('Loaded custom extension.')
+
+# The user will globally enable the below mode when calling this API
+def enable_foo_device():
+    m = FooDeviceMode()
+    holder = enable_torch_function_mode(m)
+    holder.__enter__()
+    # If you want the mode to never be disabled, then this function shouldn't return anything.
+    return holder
+
+# This is a simple TorchFunctionMode class that:
+# (a) Intercepts all torch.* calls
+# (b) Checks for kwargs of the form `device="foo:i"`
+# (c) Turns those into custom device objects: `device=foo_module.custom_device(i)`
+# (d) Forwards the call along into pytorch.
+class FooDeviceMode(TorchFunctionMode):
+    def __torch_function__(self, func, types, args=(), kwargs=None):
+        if kwargs is None:
+            kwargs = {}
+        if 'device' in kwargs and 'foo' in kwargs['device']:
+            device_and_idx = kwargs['device'].split(':')
+            if len(device_and_idx) == 1:
+                # Case 1: No index specified
+                kwargs['device'] = foo_module.custom_device()
+            else:
+                # Case 2: The user specified a device index.
+                device_idx = int(device_and_idx[1])
+                kwargs['device'] = foo_module.custom_device(device_idx)
+        with torch._C.DisableTorchFunction():
+            return func(*args, **kwargs)


### PR DESCRIPTION
cc @albanD

Main changes from the test in core are:
(1) Slightly beefed up comments
(2) Updated kernels just to print when they're called (and added the output of running the script in the comments)
(3) Showed two example user API's for a custom device: added a TorchFunctionMode that lets you pass in `device="foo"` and have things work properly